### PR TITLE
Allow all keystatic patch updates

### DIFF
--- a/components/ComponentBlocks.tsx
+++ b/components/ComponentBlocks.tsx
@@ -25,7 +25,7 @@ export const ComponentBlocks = {
         summary={props.fields.summary.value}
         linkButton={{
           externalLink: props.fields.externalLink.value,
-          href: props.fields.href.value,
+          href: props.fields.href.value || "",
           label: props.fields.linkLabel.value,
         }}
       />
@@ -34,7 +34,11 @@ export const ComponentBlocks = {
       title: fields.text({ label: "Title" }),
       summary: fields.text({ label: "Summary" }),
       linkLabel: fields.text({ label: "Link Label" }),
-      href: fields.url({ label: "Link" }),
+      href: fields.url({
+        label: "Link",
+        defaultValue: "",
+        validation: { isRequired: true },
+      }),
       externalLink: fields.checkbox({
         label: "External Link",
       }),
@@ -47,7 +51,7 @@ export const ComponentBlocks = {
         heading={props.fields.heading.value}
         bodyText={props.fields.bodyText.value}
         externalLink={{
-          href: props.fields.externalLinkHref.value,
+          href: props.fields.externalLinkHref.value || "",
           label: props.fields.externalLinkLabel.value,
         }}
       />
@@ -69,9 +73,10 @@ export const ComponentBlocks = {
   }),
   youtubeEmbed: component({
     label: "YouTube Embed",
-    preview: (props) => (
-      <YouTubeEmbed youtubeLink={props.fields.youtubeLink.value} />
-    ),
+    preview: (props) => {
+      const youtubeLink = props.fields.youtubeLink.value;
+      return youtubeLink ? <YouTubeEmbed youtubeLink={youtubeLink} /> : null;
+    },
     schema: {
       youtubeLink: fields.url({
         label: "YouTube URL",
@@ -80,7 +85,7 @@ export const ComponentBlocks = {
   }),
   tweetEmbed: component({
     label: "Tweet Embed",
-    preview: (props) => <TweetEmbed tweet={props.fields.tweet.value} />,
+    preview: (props) => <TweetEmbed tweet={props.fields.tweet.value || ""} />,
     schema: {
       tweet: fields.url({
         label: "Tweet URL",
@@ -132,7 +137,7 @@ export const ComponentBlocks = {
         quote={props.fields.quote.value}
         author={props.fields.author.value}
         workplaceOrSocial={props.fields.workplaceOrSocial.value}
-        socialLink={props.fields.socialLink.value}
+        socialLink={props.fields.socialLink.value || ""}
       />
     ),
     schema: {

--- a/package.json
+++ b/package.json
@@ -3,12 +3,12 @@
   "private": true,
   "version": "0.0.0",
   "dependencies": {
-    "@keystatic/core": "0.0.98",
-    "@keystatic/next": "0.0.7",
+    "@keystatic/core": "0.0.x",
+    "@keystatic/next": "0.0.x",
     "@types/react": "^18.2.6",
     "@types/react-dom": "^18.2.4",
     "date-fns": "^2.30.0",
-    "next": "^13.4.1",
+    "next": "^13.4.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "typescript": "^4.9.5"

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "version": "0.0.0",
   "dependencies": {
-    "@keystatic/core": "0.0.x",
-    "@keystatic/next": "0.0.x",
+    "@keystatic/core": "^0.0.x",
+    "@keystatic/next": "^0.0.x",
     "@types/react": "^18.2.6",
     "@types/react-dom": "^18.2.4",
     "date-fns": "^2.30.0",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "version": "0.0.0",
   "dependencies": {
-    "@keystatic/core": "^0.0.104",
-    "@keystatic/next": "^0.0.7",
+    "@keystatic/core": "0.0.104",
+    "@keystatic/next": "0.0.7",
     "@types/react": "^18.2.6",
     "@types/react-dom": "^18.2.4",
     "date-fns": "^2.30.0",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "version": "0.0.0",
   "dependencies": {
-    "@keystatic/core": "0.0.104",
-    "@keystatic/next": "0.0.7",
+    "@keystatic/core": "^0.0.104",
+    "@keystatic/next": "^0.0.7",
     "@types/react": "^18.2.6",
     "@types/react-dom": "^18.2.4",
     "date-fns": "^2.30.0",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "version": "0.0.0",
   "dependencies": {
-    "@keystatic/core": "^0.0.x",
-    "@keystatic/next": "^0.0.x",
+    "@keystatic/core": "^0.0.104",
+    "@keystatic/next": "^0.0.7",
     "@types/react": "^18.2.6",
     "@types/react-dom": "^18.2.4",
     "date-fns": "^2.30.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,10 +2,10 @@ lockfileVersion: '6.0'
 
 dependencies:
   '@keystatic/core':
-    specifier: ^0.0.x
+    specifier: ^0.0.104
     version: 0.0.104(react-dom@18.2.0)(react@18.2.0)
   '@keystatic/next':
-    specifier: ^0.0.x
+    specifier: ^0.0.7
     version: 0.0.7(@keystatic/core@0.0.104)(next@13.4.4)(react-dom@18.2.0)(react@18.2.0)
   '@types/react':
     specifier: ^18.2.6

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,10 +2,10 @@ lockfileVersion: '6.0'
 
 dependencies:
   '@keystatic/core':
-    specifier: ^0.0.104
+    specifier: 0.0.104
     version: 0.0.104(react-dom@18.2.0)(react@18.2.0)
   '@keystatic/next':
-    specifier: ^0.0.7
+    specifier: 0.0.7
     version: 0.0.7(@keystatic/core@0.0.104)(next@13.4.4)(react-dom@18.2.0)(react@18.2.0)
   '@types/react':
     specifier: ^18.2.6

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,11 +2,11 @@ lockfileVersion: '6.0'
 
 dependencies:
   '@keystatic/core':
-    specifier: 0.0.98
-    version: 0.0.98(react-dom@18.2.0)(react@18.2.0)
+    specifier: 0.0.x
+    version: 0.0.104(react-dom@18.2.0)(react@18.2.0)
   '@keystatic/next':
-    specifier: 0.0.7
-    version: 0.0.7(@keystatic/core@0.0.98)(next@13.4.1)(react-dom@18.2.0)(react@18.2.0)
+    specifier: 0.0.x
+    version: 0.0.7(@keystatic/core@0.0.104)(next@13.4.4)(react-dom@18.2.0)(react@18.2.0)
   '@types/react':
     specifier: ^18.2.6
     version: 18.2.6
@@ -17,8 +17,8 @@ dependencies:
     specifier: ^2.30.0
     version: 2.30.0
   next:
-    specifier: ^13.4.1
-    version: 13.4.1(react-dom@18.2.0)(react@18.2.0)
+    specifier: ^13.4.4
+    version: 13.4.4(react-dom@18.2.0)(react@18.2.0)
   react:
     specifier: ^18.2.0
     version: 18.2.0
@@ -333,8 +333,8 @@ packages:
     resolution: {integrity: sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==}
     dev: false
 
-  /@keystatic/core@0.0.98(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-Lugdos3tr90nDW8CM1DGpJNh9Zv5zcFxxGo6ShMC+yiYgHmJG35wE6TY6J8OeNRw1dvyldB7KMufKbyZlO4kgw==}
+  /@keystatic/core@0.0.104(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-NiSa/JmFT0xt3OTq3QNCgpf4FxchYsJ5IO6xKOHEp4g3LR5PRCg6BEiF9loLCyPWMRhtqc4daWPfyogfv86IYA==}
     peerDependencies:
       react: ^18.2.0
       react-dom: ^18.2.0
@@ -431,7 +431,7 @@ packages:
       - supports-color
     dev: false
 
-  /@keystatic/next@0.0.7(@keystatic/core@0.0.98)(next@13.4.1)(react-dom@18.2.0)(react@18.2.0):
+  /@keystatic/next@0.0.7(@keystatic/core@0.0.104)(next@13.4.4)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-e/stO9ZH+q/Hs++jF6eAA/F6Zyv55QY9K228/6S1rWbizs8w4STgTaCnfye+dCXWLkZAKFhWQv5E0aGpccyXVQ==}
     peerDependencies:
       '@keystatic/core': '*'
@@ -440,10 +440,10 @@ packages:
       react-dom: ^18.2.0
     dependencies:
       '@babel/runtime': 7.21.5
-      '@keystatic/core': 0.0.98(react-dom@18.2.0)(react@18.2.0)
+      '@keystatic/core': 0.0.104(react-dom@18.2.0)(react@18.2.0)
       '@types/react': 18.2.6
       chokidar: 3.5.3
-      next: 13.4.1(react-dom@18.2.0)(react@18.2.0)
+      next: 13.4.4(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       server-only: 0.0.1
@@ -467,12 +467,12 @@ packages:
       '@types/markdown-it': 12.2.3
     dev: false
 
-  /@next/env@13.4.1:
-    resolution: {integrity: sha512-eD6WCBMFjLFooLM19SIhSkWBHtaFrZFfg2Cxnyl3vS3DAdFRfnx5TY2RxlkuKXdIRCC0ySbtK9JXXt8qLCqzZg==}
+  /@next/env@13.4.4:
+    resolution: {integrity: sha512-q/y7VZj/9YpgzDe64Zi6rY1xPizx80JjlU2BTevlajtaE3w1LqweH1gGgxou2N7hdFosXHjGrI4OUvtFXXhGLg==}
     dev: false
 
-  /@next/swc-darwin-arm64@13.4.1:
-    resolution: {integrity: sha512-eF8ARHtYfnoYtDa6xFHriUKA/Mfj/cCbmKb3NofeKhMccs65G6/loZ15a6wYCCx4rPAd6x4t1WmVYtri7EdeBg==}
+  /@next/swc-darwin-arm64@13.4.4:
+    resolution: {integrity: sha512-xfjgXvp4KalNUKZMHmsFxr1Ug+aGmmO6NWP0uoh4G3WFqP/mJ1xxfww0gMOeMeSq/Jyr5k7DvoZ2Pv+XOITTtw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -480,8 +480,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-darwin-x64@13.4.1:
-    resolution: {integrity: sha512-7cmDgF9tGWTgn5Gw+vP17miJbH4wcraMHDCOHTYWkO/VeKT73dUWG23TNRLfgtCNSPgH4V5B4uLHoZTanx9bAw==}
+  /@next/swc-darwin-x64@13.4.4:
+    resolution: {integrity: sha512-ZY9Ti1hkIwJsxGus3nlubIkvYyB0gNOYxKrfsOrLEqD0I2iCX8D7w8v6QQZ2H+dDl6UT29oeEUdDUNGk4UEpfg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
@@ -489,8 +489,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-linux-arm64-gnu@13.4.1:
-    resolution: {integrity: sha512-qwJqmCri2ie8aTtE5gjTSr8S6O8B67KCYgVZhv9gKH44yvc/zXbAY8u23QGULsYOyh1islWE5sWfQNLOj9iryg==}
+  /@next/swc-linux-arm64-gnu@13.4.4:
+    resolution: {integrity: sha512-+KZnDeMShYkpkqAvGCEDeqYTRADJXc6SY1jWXz+Uo6qWQO/Jd9CoyhTJwRSxvQA16MoYzvILkGaDqirkRNctyA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -498,8 +498,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-linux-arm64-musl@13.4.1:
-    resolution: {integrity: sha512-qcC54tWNGDv/VVIFkazxhqH1Bnagjfs4enzELVRlUOoJPD2BGJTPI7z08pQPbbgxLtRiu8gl2mXvpB8WlOkMeA==}
+  /@next/swc-linux-arm64-musl@13.4.4:
+    resolution: {integrity: sha512-evC1twrny2XDT4uOftoubZvW3EG0zs0ZxMwEtu/dDGVRO5n5pT48S8qqEIBGBUZYu/Xx4zzpOkIxx1vpWdE+9A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -507,8 +507,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-linux-x64-gnu@13.4.1:
-    resolution: {integrity: sha512-9TeWFlpLsBosZ+tsm/rWBaMwt5It9tPH8m3nawZqFUUrZyGRfGcI67js774vtx0k3rL9qbyY6+3pw9BCVpaYUA==}
+  /@next/swc-linux-x64-gnu@13.4.4:
+    resolution: {integrity: sha512-PX706XcCHr2FfkyhP2lpf+pX/tUvq6/ke7JYnnr0ykNdEMo+sb7cC/o91gnURh4sPYSiZJhsF2gbIqg9rciOHQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -516,8 +516,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-linux-x64-musl@13.4.1:
-    resolution: {integrity: sha512-sNDGaWmSqTS4QRUzw61wl4mVPeSqNIr1OOjLlQTRuyInxMxtqImRqdvzDvFTlDfdeUMU/DZhWGYoHrXLlZXe6A==}
+  /@next/swc-linux-x64-musl@13.4.4:
+    resolution: {integrity: sha512-TKUUx3Ftd95JlHV6XagEnqpT204Y+IsEa3awaYIjayn0MOGjgKZMZibqarK3B1FsMSPaieJf2FEAcu9z0yT5aA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -525,8 +525,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-win32-arm64-msvc@13.4.1:
-    resolution: {integrity: sha512-+CXZC7u1iXdLRudecoUYbhbsXpglYv8KFYsFxKBPn7kg+bk7eJo738wAA4jXIl8grTF2mPdmO93JOQym+BlYGA==}
+  /@next/swc-win32-arm64-msvc@13.4.4:
+    resolution: {integrity: sha512-FP8AadgSq4+HPtim7WBkCMGbhr5vh9FePXiWx9+YOdjwdQocwoCK5ZVC3OW8oh3TWth6iJ0AXJ/yQ1q1cwSZ3A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
@@ -534,8 +534,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-win32-ia32-msvc@13.4.1:
-    resolution: {integrity: sha512-vIoXVVc7UYO68VwVMDKwJC2+HqAZQtCYiVlApyKEeIPIQpz2gpufzGxk1z3/gwrJt/kJ5CDZjlhYDCzd3hdz+g==}
+  /@next/swc-win32-ia32-msvc@13.4.4:
+    resolution: {integrity: sha512-3WekVmtuA2MCdcAOrgrI+PuFiFURtSyyrN1I3UPtS0ckR2HtLqyqmS334Eulf15g1/bdwMteePdK363X/Y9JMg==}
     engines: {node: '>= 10'}
     cpu: [ia32]
     os: [win32]
@@ -543,8 +543,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-win32-x64-msvc@13.4.1:
-    resolution: {integrity: sha512-n8V5ImLQZibKTu10UUdI3nIeTLkliEXe628qxqW9v8My3BAH2a7H0SaCqkV2OgqFnn8sG1wxKYw9/SNJ632kSA==}
+  /@next/swc-win32-x64-msvc@13.4.4:
+    resolution: {integrity: sha512-AHRITu/CrlQ+qzoqQtEMfaTu7GHaQ6bziQln/pVWpOYC1wU+Mq6VQQFlsDtMCnDztPZtppAXdvvbNS7pcfRzlw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -3563,14 +3563,13 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  /next@13.4.1(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-JBw2kAIyhKDpjhEWvNVoFeIzNp9xNxg8wrthDOtMctfn3EpqGCmW0FSviNyGgOSOSn6zDaX48pmvbdf6X2W9xA==}
+  /next@13.4.4(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-C5S0ysM0Ily9McL4Jb48nOQHT1BukOWI59uC3X/xCMlYIh9rJZCv7nzG92J6e1cOBqQbKovlpgvHWFmz4eKKEA==}
     engines: {node: '>=16.8.0'}
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
       fibers: '>= 3.1.0'
-      node-sass: ^6.0.0 || ^7.0.0
       react: ^18.2.0
       react-dom: ^18.2.0
       sass: ^1.3.0
@@ -3579,12 +3578,10 @@ packages:
         optional: true
       fibers:
         optional: true
-      node-sass:
-        optional: true
       sass:
         optional: true
     dependencies:
-      '@next/env': 13.4.1
+      '@next/env': 13.4.4
       '@swc/helpers': 0.5.1
       busboy: 1.6.0
       caniuse-lite: 1.0.30001486
@@ -3594,15 +3591,15 @@ packages:
       styled-jsx: 5.1.1(react@18.2.0)
       zod: 3.21.4
     optionalDependencies:
-      '@next/swc-darwin-arm64': 13.4.1
-      '@next/swc-darwin-x64': 13.4.1
-      '@next/swc-linux-arm64-gnu': 13.4.1
-      '@next/swc-linux-arm64-musl': 13.4.1
-      '@next/swc-linux-x64-gnu': 13.4.1
-      '@next/swc-linux-x64-musl': 13.4.1
-      '@next/swc-win32-arm64-msvc': 13.4.1
-      '@next/swc-win32-ia32-msvc': 13.4.1
-      '@next/swc-win32-x64-msvc': 13.4.1
+      '@next/swc-darwin-arm64': 13.4.4
+      '@next/swc-darwin-x64': 13.4.4
+      '@next/swc-linux-arm64-gnu': 13.4.4
+      '@next/swc-linux-arm64-musl': 13.4.4
+      '@next/swc-linux-x64-gnu': 13.4.4
+      '@next/swc-linux-x64-musl': 13.4.4
+      '@next/swc-win32-arm64-msvc': 13.4.4
+      '@next/swc-win32-ia32-msvc': 13.4.4
+      '@next/swc-win32-x64-msvc': 13.4.4
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,10 +2,10 @@ lockfileVersion: '6.0'
 
 dependencies:
   '@keystatic/core':
-    specifier: 0.0.x
+    specifier: ^0.0.x
     version: 0.0.104(react-dom@18.2.0)(react@18.2.0)
   '@keystatic/next':
-    specifier: 0.0.x
+    specifier: ^0.0.x
     version: 0.0.7(@keystatic/core@0.0.104)(next@13.4.4)(react-dom@18.2.0)(react@18.2.0)
   '@types/react':
     specifier: ^18.2.6

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,10 +2,10 @@ lockfileVersion: '6.0'
 
 dependencies:
   '@keystatic/core':
-    specifier: 0.0.104
+    specifier: ^0.0.104
     version: 0.0.104(react-dom@18.2.0)(react@18.2.0)
   '@keystatic/next':
-    specifier: 0.0.7
+    specifier: ^0.0.7
     version: 0.0.7(@keystatic/core@0.0.104)(next@13.4.4)(react-dom@18.2.0)(react@18.2.0)
   '@types/react':
     specifier: ^18.2.6


### PR DESCRIPTION
Some installations of the starter template are throwing on navigation to `/keystatic`. Updating the `@keystatic` packages to the latest versions fixes the issue. 